### PR TITLE
feat: add BuildBattles spectator and reconnect continuity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           # Keep cross-repository builds reproducible. Update this SHA alongside
           # coordinated CookieDough API changes; the repository variable is an
           # explicit escape hatch for compatibility testing.
-          ref: ${{ vars.COOKIE_DOUGH_REF || 'aa65641843ad947a145e2a5e4d2350b4c5bf6cad' }}
+          ref: ${{ vars.COOKIE_DOUGH_REF || '76d2b591e811eacfd312815044b16c5e599f09aa' }}
           path: CookieDough
 
       - name: Set up Java 25

--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,9 @@ repositories {
 dependencies {
     implementation project(path: ':CookieDough', configuration: 'shadow')
     compileOnly 'jakarta.persistence:jakarta.persistence-api:3.2.0'
-    compileOnly 'io.papermc.paper:paper-api:26.1.2.build.74-stable'
+    compileOnly 'io.papermc.paper:paper-api:26.2.build.116-stable'
     compileOnly 'org.geysermc.cumulus:cumulus:1.1.2'
-    testImplementation 'io.papermc.paper:paper-api:26.1.2.build.74-stable'
+    testImplementation 'io.papermc.paper:paper-api:26.2.build.116-stable'
     testImplementation 'org.geysermc.cumulus:cumulus:1.1.2'
     testImplementation platform('org.junit:junit-bom:5.12.2')
     testImplementation 'org.junit.jupiter:junit-jupiter'
@@ -56,6 +56,8 @@ processResources {
 
 def mapInstallDirectory = providers.gradleProperty('cookiebuildBuildBattlesMapInstallDir')
         .map { rootProject.file(it) }
+        .orElse(providers.environmentVariable('COOKIEBUILD_E2E_SERVER_DIR')
+                .map { new File(it, 'buildbattles_maps') })
         .orElse(provider {
             new File(rootProject.projectDir.parentFile, 'Paper26_Test_Server/buildbattles_maps')
         })

--- a/src/main/java/com/cookiebuild/buildbattles/game/BuildBattlesGame.java
+++ b/src/main/java/com/cookiebuild/buildbattles/game/BuildBattlesGame.java
@@ -932,10 +932,18 @@ public final class BuildBattlesGame extends Game implements ReconnectableGame {
         }
         if (!ejectOwnedPlayersToLobby()) {
             cleanupStarted = false;
-            BuildBattles.getInstance().getLogger().warning(
-                    "Deferring BuildBattles map cleanup until every player reaches the lobby: " + getGameId());
-            cleanupRetryTask = Bukkit.getScheduler().runTaskLater(
-                    BuildBattles.getInstance(), this::cleanup, 20L);
+            BuildBattles plugin = BuildBattles.getInstance();
+            if (plugin != null) {
+                plugin.getLogger().warning(
+                        "Deferring BuildBattles map cleanup until every player reaches the lobby: " + getGameId());
+            }
+            if (plugin != null && plugin.isEnabled()) {
+                try {
+                    cleanupRetryTask = Bukkit.getScheduler().runTaskLater(plugin, this::cleanup, 20L);
+                } catch (RuntimeException error) {
+                    plugin.getLogger().warning("Could not schedule BuildBattles cleanup retry: " + error.getMessage());
+                }
+            }
             return;
         }
         cancelFloorTasks();

--- a/src/main/java/com/cookiebuild/buildbattles/game/BuildBattlesGame.java
+++ b/src/main/java/com/cookiebuild/buildbattles/game/BuildBattlesGame.java
@@ -172,7 +172,7 @@ public final class BuildBattlesGame extends Game implements ReconnectableGame {
         cookiePlayer.resetPlayer();
         player.setGameMode(GameMode.ADVENTURE);
         player.setAllowFlight(false);
-        player.teleport(map.template().waitingSpawn(map.world()));
+        teleportPlayerSafely(player, map.template().waitingSpawn(map.world()));
         for (int index = 0; index < themeBallot.candidates().size(); index++) {
             String candidate = themeBallot.candidates().get(index);
             ItemStack paper = new ItemStack(Material.PAPER);
@@ -309,12 +309,16 @@ public final class BuildBattlesGame extends Game implements ReconnectableGame {
     }
 
     private void prepareBuilder(CookiePlayer cookiePlayer, int plot) {
+        prepareBuilder(cookiePlayer, plot, true);
+    }
+
+    private void prepareBuilder(CookiePlayer cookiePlayer, int plot, boolean teleport) {
         Player player = cookiePlayer.getPlayer();
         cookiePlayer.resetPlayer();
         cookiePlayer.setState(PlayerState.IN_GAME);
         player.setGameMode(GameMode.CREATIVE);
         player.setAllowFlight(true);
-        player.teleport(map.template().plotCenter(map.world(), plot));
+        if (teleport) teleportPlayerSafely(player, map.template().plotCenter(map.world(), plot));
         BuildBattles.givePaletteShortcut(player);
         player.sendMessage(Component.text(BuildBattles.message(player, "bb.floor.hint"), NamedTextColor.YELLOW));
         player.sendMessage(Component.text(BuildBattles.message(player, "bb.build.palette"), NamedTextColor.AQUA));
@@ -823,11 +827,19 @@ public final class BuildBattlesGame extends Game implements ReconnectableGame {
         long grace = BuildBattles.getInstance().getConfig().getLong("game.reconnect-grace-seconds", 60) * 1000L;
         if (disconnected == null || System.currentTimeMillis() - disconnected > grace
                 || phase == BuildPhase.WAITING || phase == BuildPhase.FINISHED) return false;
+        Integer plot = plotByPlayer.get(id);
+        if (phase == BuildPhase.BUILDING && plot == null) return false;
+        Location destination = phase == BuildPhase.BUILDING && plot != null
+                ? map.template().plotCenter(map.world(), plot)
+                : judgingPlot >= 0 ? map.template().judgingLocation(map.world(), judgingPlot)
+                : map.template().waitingSpawn(map.world());
+        if (!canRestorePlayerAfterReconnect(cookiePlayer)
+                || !tryTeleportPlayerSafely(cookiePlayer.getPlayer(), destination)) return false;
         if (!restorePlayerAfterReconnect(cookiePlayer)) return false;
         activePlayers.put(id, cookiePlayer);
         disconnectedAt.remove(id);
         if (phase == BuildPhase.BUILDING) {
-            prepareBuilder(cookiePlayer, plotByPlayer.get(id));
+            prepareBuilder(cookiePlayer, plot, false);
         } else {
             cookiePlayer.resetPlayer();
             cookiePlayer.setState(PlayerState.SPECTATING);
@@ -835,9 +847,8 @@ public final class BuildBattlesGame extends Game implements ReconnectableGame {
             player.setGameMode(GameMode.ADVENTURE);
             player.setAllowFlight(true);
             player.setFlying(true);
-            Location destination = judgingPlot >= 0 ? map.template().judgingLocation(map.world(), judgingPlot)
-                    : map.template().waitingSpawn(map.world());
-            player.teleport(destination);
+            CookieDough.getInstance().getPlayerTransitionFlightGuard()
+                    .protectLanding(player, true, true);
             if (phase == BuildPhase.JUDGING) giveVoteItems(player);
         }
         cookiePlayer.getPlayer().sendMessage(Component.text(

--- a/src/main/java/com/cookiebuild/buildbattles/game/BuildBattlesGame.java
+++ b/src/main/java/com/cookiebuild/buildbattles/game/BuildBattlesGame.java
@@ -104,6 +104,7 @@ public final class BuildBattlesGame extends Game implements ReconnectableGame {
     private int judgingPlot = -1;
     private boolean outcomePersisted;
     private boolean cleanupStarted;
+    private BukkitTask cleanupRetryTask;
 
     private record PendingMatchOutcome(Set<UUID> winners, List<MatchService.Performance> performances) {
         private PendingMatchOutcome {
@@ -925,6 +926,18 @@ public final class BuildBattlesGame extends Game implements ReconnectableGame {
         cleanupStarted = true;
         phase = BuildPhase.FINISHED;
         setState(GameState.FINISHED);
+        if (cleanupRetryTask != null) {
+            cleanupRetryTask.cancel();
+            cleanupRetryTask = null;
+        }
+        if (!ejectOwnedPlayersToLobby()) {
+            cleanupStarted = false;
+            BuildBattles.getInstance().getLogger().warning(
+                    "Deferring BuildBattles map cleanup until every player reaches the lobby: " + getGameId());
+            cleanupRetryTask = Bukkit.getScheduler().runTaskLater(
+                    BuildBattles.getInstance(), this::cleanup, 20L);
+            return;
+        }
         cancelFloorTasks();
         for (UUID entityId : resources.trackedEntityIds()) {
             Entity entity = map.world().getEntity(entityId);
@@ -952,7 +965,6 @@ public final class BuildBattlesGame extends Game implements ReconnectableGame {
             }
         }
         activePlayers.clear();
-        ejectSpectatorsToLobby();
         if (!MapManager.unload(getGameId())) {
             BuildBattles.getInstance().getLogger().warning("Map cleanup remains pending for " + getGameId());
         }

--- a/src/main/java/com/cookiebuild/buildbattles/game/BuildBattlesGame.java
+++ b/src/main/java/com/cookiebuild/buildbattles/game/BuildBattlesGame.java
@@ -301,16 +301,11 @@ public final class BuildBattlesGame extends Game implements ReconnectableGame {
     }
 
     @Override
-    protected boolean teleportToSpectator(CookiePlayer cookiePlayer) {
-        if (map == null || map.world() == null) return false;
-        Player player = cookiePlayer.getPlayer();
-        Location destination = judgingPlot >= 0
+    protected Location spectatorDestination(CookiePlayer cookiePlayer) {
+        if (map == null || map.world() == null) return null;
+        return judgingPlot >= 0
                 ? map.template().judgingLocation(map.world(), judgingPlot)
                 : map.template().waitingSpawn(map.world());
-        if (!destination.getChunk().load() || !player.teleport(destination)) return false;
-        cookiePlayer.resetPlayer();
-        player.setGameMode(GameMode.SPECTATOR);
-        return true;
     }
 
     private void prepareBuilder(CookiePlayer cookiePlayer, int plot) {

--- a/src/main/java/com/cookiebuild/buildbattles/game/BuildBattlesGame.java
+++ b/src/main/java/com/cookiebuild/buildbattles/game/BuildBattlesGame.java
@@ -48,6 +48,7 @@ import com.cookiebuild.cookiedough.game.FunnelTelemetry;
 import com.cookiebuild.cookiedough.game.Game;
 import com.cookiebuild.cookiedough.game.GameManager;
 import com.cookiebuild.cookiedough.game.GameState;
+import com.cookiebuild.cookiedough.game.ReconnectableGame;
 import com.cookiebuild.cookiedough.lobby.LobbyManager;
 import com.cookiebuild.cookiedough.lobby.LobbyScoreboard;
 import com.cookiebuild.cookiedough.model.Match;
@@ -64,7 +65,7 @@ import com.cookiebuild.cookiedough.ui.MenuLore;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.title.Title;
 
-public final class BuildBattlesGame extends Game {
+public final class BuildBattlesGame extends Game implements ReconnectableGame {
     public static final String MINIGAME_KEY = "buildbattles";
 
     public enum FloorChangeResult {
@@ -292,6 +293,24 @@ public final class BuildBattlesGame extends Game {
         Integer plot = plotByPlayer.get(cookiePlayer.getPlayer().getUniqueId());
         if (plot == null) throw new IllegalStateException("Player has no assigned plot");
         prepareBuilder(cookiePlayer, plot);
+    }
+
+    @Override
+    public boolean supportsSpectating() {
+        return true;
+    }
+
+    @Override
+    protected boolean teleportToSpectator(CookiePlayer cookiePlayer) {
+        if (map == null || map.world() == null) return false;
+        Player player = cookiePlayer.getPlayer();
+        Location destination = judgingPlot >= 0
+                ? map.template().judgingLocation(map.world(), judgingPlot)
+                : map.template().waitingSpawn(map.world());
+        if (!destination.getChunk().load() || !player.teleport(destination)) return false;
+        cookiePlayer.resetPlayer();
+        player.setGameMode(GameMode.SPECTATOR);
+        return true;
     }
 
     private void prepareBuilder(CookiePlayer cookiePlayer, int plot) {
@@ -831,6 +850,14 @@ public final class BuildBattlesGame extends Game {
         return true;
     }
 
+    @Override
+    public boolean hasReconnectReservation(UUID playerId) {
+        if (playerId == null || phase == BuildPhase.WAITING || phase == BuildPhase.FINISHED) return false;
+        Long disconnected = disconnectedAt.get(playerId);
+        long grace = BuildBattles.getInstance().getConfig().getLong("game.reconnect-grace-seconds", 60) * 1000L;
+        return disconnected != null && System.currentTimeMillis() - disconnected <= grace;
+    }
+
     private boolean stopAbandonedMatch() {
         long now = System.currentTimeMillis();
         long grace = BuildBattles.getInstance().getConfig().getLong("game.reconnect-grace-seconds", 60) * 1000L;
@@ -855,6 +882,12 @@ public final class BuildBattlesGame extends Game {
     @Override
     public synchronized void removePlayer(CookiePlayer player, String reason) {
         UUID id = player.getPlayer().getUniqueId();
+        if (getSpectators().stream().anyMatch(viewer ->
+                viewer.getPlayer().getUniqueId().equals(id))) {
+            super.removePlayer(player, reason);
+            scoreboard.remove(player.getPlayer());
+            return;
+        }
         if (phase == BuildPhase.WAITING) {
             if (getPlayers().contains(player)) super.removePlayer(player, reason);
             participants.remove(id);
@@ -913,6 +946,7 @@ public final class BuildBattlesGame extends Game {
             }
         }
         activePlayers.clear();
+        ejectSpectatorsToLobby();
         if (!MapManager.unload(getGameId())) {
             BuildBattles.getInstance().getLogger().warning("Map cleanup remains pending for " + getGameId());
         }

--- a/src/main/java/com/cookiebuild/buildbattles/listener/BuildBattlesListener.java
+++ b/src/main/java/com/cookiebuild/buildbattles/listener/BuildBattlesListener.java
@@ -40,7 +40,6 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
-import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.vehicle.VehicleCreateEvent;
@@ -448,17 +447,6 @@ public final class BuildBattlesListener implements Listener {
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onConsume(PlayerItemConsumeEvent event) {
         if (BuildBattles.findGame(event.getPlayer()) != null) event.setCancelled(true);
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR)
-    public void onJoin(PlayerJoinEvent event) {
-        Bukkit.getScheduler().runTaskLater(BuildBattles.getInstance(), () -> {
-            CookiePlayer cookiePlayer = PlayerManager.getPlayer(event.getPlayer());
-            if (cookiePlayer == null) return;
-            for (Game candidate : GameManager.getGames()) {
-                if (candidate instanceof BuildBattlesGame game && game.reconnect(cookiePlayer)) return;
-            }
-        }, 10L);
     }
 
     @EventHandler(priority = EventPriority.MONITOR)

--- a/src/main/java/com/cookiebuild/buildbattles/ui/BuildBattlesBedrockForms.java
+++ b/src/main/java/com/cookiebuild/buildbattles/ui/BuildBattlesBedrockForms.java
@@ -39,7 +39,7 @@ public final class BuildBattlesBedrockForms {
         BedrockFormImages.button(form, BedrockButtonText.format(
                 BuildBattles.message(player, "bb.form.close")), CLOSE_IMAGE);
         form.validResultHandler(response -> {
-            int index = response.getClickedButtonId();
+            int index = response.clickedButtonId();
             MainThreadPlayerAction.dispatch(plugin, player, () -> {
                 if (SESSIONS.consume(player.getUniqueId(), nonce, scope)
                         && index >= 0 && index < options.size()) voteHandler.accept(options.get(index));
@@ -67,7 +67,7 @@ public final class BuildBattlesBedrockForms {
         BedrockFormImages.button(form, BedrockButtonText.format(
                 BuildBattles.message(player, "bb.form.close")), CLOSE_IMAGE);
         form.validResultHandler(response -> {
-            int index = response.getClickedButtonId();
+            int index = response.clickedButtonId();
             MainThreadPlayerAction.dispatch(plugin, player, () -> {
                 if (SESSIONS.consume(player.getUniqueId(), nonce, scope)
                         && index >= 0 && index < 5) voteHandler.accept(index + 1);
@@ -94,7 +94,7 @@ public final class BuildBattlesBedrockForms {
         BedrockFormImages.button(form, BedrockButtonText.format(
                 BuildBattles.message(player, "bb.form.close")), CLOSE_IMAGE);
         form.validResultHandler(response -> {
-            int index = response.getClickedButtonId();
+            int index = response.clickedButtonId();
             MainThreadPlayerAction.dispatch(plugin, player, () -> {
                 if (SESSIONS.consume(player.getUniqueId(), nonce, scope) && index == 0) receiveHandler.run();
             });

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: BuildBattles
 version: '${version}'
 main: com.cookiebuild.buildbattles.BuildBattles
-api-version: '26.1.2'
+api-version: '26.2'
 load: POSTWORLD
 depend: [CookieDough]
 

--- a/src/test/java/com/cookiebuild/buildbattles/game/BuildBattlesContinuityContractTest.java
+++ b/src/test/java/com/cookiebuild/buildbattles/game/BuildBattlesContinuityContractTest.java
@@ -20,5 +20,7 @@ class BuildBattlesContinuityContractTest {
                 < removal.indexOf("if (phase == BuildPhase.WAITING)"));
         assertTrue(source.indexOf("if (!ejectOwnedPlayersToLobby())")
                 < source.indexOf("MapManager.unload(getGameId())"));
+        assertTrue(source.indexOf("plugin != null && plugin.isEnabled()")
+                < source.indexOf("this::cleanup, 20L"));
     }
 }

--- a/src/test/java/com/cookiebuild/buildbattles/game/BuildBattlesContinuityContractTest.java
+++ b/src/test/java/com/cookiebuild/buildbattles/game/BuildBattlesContinuityContractTest.java
@@ -1,0 +1,23 @@
+package com.cookiebuild.buildbattles.game;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+class BuildBattlesContinuityContractTest {
+    @Test
+    void spectatorQuitBypassesParticipantReconnectAndCleanupEjectsBeforeUnload() throws Exception {
+        String source = Files.readString(Path.of(
+                "src/main/java/com/cookiebuild/buildbattles/game/BuildBattlesGame.java"));
+        String removal = source.substring(source.indexOf("public synchronized void removePlayer"));
+        assertTrue(source.contains("implements ReconnectableGame"));
+        assertTrue(source.contains("public boolean supportsSpectating()"));
+        assertTrue(removal.indexOf("getSpectators().stream()")
+                < removal.indexOf("if (phase == BuildPhase.WAITING)"));
+        assertTrue(source.indexOf("ejectSpectatorsToLobby();")
+                < source.indexOf("MapManager.unload(getGameId())"));
+    }
+}

--- a/src/test/java/com/cookiebuild/buildbattles/game/BuildBattlesContinuityContractTest.java
+++ b/src/test/java/com/cookiebuild/buildbattles/game/BuildBattlesContinuityContractTest.java
@@ -18,7 +18,7 @@ class BuildBattlesContinuityContractTest {
         assertTrue(source.contains("protected Location spectatorDestination"));
         assertTrue(removal.indexOf("getSpectators().stream()")
                 < removal.indexOf("if (phase == BuildPhase.WAITING)"));
-        assertTrue(source.indexOf("ejectSpectatorsToLobby();")
+        assertTrue(source.indexOf("if (!ejectOwnedPlayersToLobby())")
                 < source.indexOf("MapManager.unload(getGameId())"));
     }
 }

--- a/src/test/java/com/cookiebuild/buildbattles/game/BuildBattlesContinuityContractTest.java
+++ b/src/test/java/com/cookiebuild/buildbattles/game/BuildBattlesContinuityContractTest.java
@@ -15,6 +15,7 @@ class BuildBattlesContinuityContractTest {
         String removal = source.substring(source.indexOf("public synchronized void removePlayer"));
         assertTrue(source.contains("implements ReconnectableGame"));
         assertTrue(source.contains("public boolean supportsSpectating()"));
+        assertTrue(source.contains("protected Location spectatorDestination"));
         assertTrue(removal.indexOf("getSpectators().stream()")
                 < removal.indexOf("if (phase == BuildPhase.WAITING)"));
         assertTrue(source.indexOf("ejectSpectatorsToLobby();")


### PR DESCRIPTION
Adds external spectator cleanup, safe reconnect reservations, arena-unload ordering, and continuity contract coverage.\n\nValidation: Gradle build and mode contracts green.